### PR TITLE
Wait for the process to exit for it to be properly released

### DIFF
--- a/lib/shell_command.go
+++ b/lib/shell_command.go
@@ -38,9 +38,12 @@ func NewShellCommand(c string) (ShellCommand, error) {
 
 	sc.Reader = io.MultiReader(stdout, stderr)
 
-	return sc, sc.cmd.Start()
+	err = sc.cmd.Start()
+
+	return sc, err
 }
 
 func (sc *shellCommand) Close() error {
+	sc.cmd.Wait()
 	return syscall.Kill(-sc.cmd.Process.Pid, syscall.SIGTERM)
 }


### PR DESCRIPTION
Without this, every child process ends up as a zombie and isn't reclaimed by the OS until the main `rat` process exits.