### PR TITLE
Run Wait after the process is signaled

### DIFF
--- a/lib/shell_command.go
+++ b/lib/shell_command.go
@@ -44,6 +44,7 @@ func NewShellCommand(c string) (ShellCommand, error) {
 }
 
 func (sc *shellCommand) Close() error {
+	err := syscall.Kill(-sc.cmd.Process.Pid, syscall.SIGTERM)
 	sc.cmd.Wait()
-	return syscall.Kill(-sc.cmd.Process.Pid, syscall.SIGTERM)
+	return err
 }


### PR DESCRIPTION
Have to send the signal first, then Wait for the process to exit. Otherwise we don't send the signal until it's already exited...