### PR TITLE
More conventional dotfile loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ $ go build && go install
 
 ### Configure
 
-Rat is configured through a file `.ratrc` in your home config directory (`~/.config/rat/.ratrc`).
+Rat is configured through a file `ratrc` in your home config directory ([`$XDG_CONFIG_HOME/rat`](https://specifications.freedesktop.org/basedir-spec/latest), `~/.config/rat` by default).
 
 Rat pagers can be opened in one or more "modes". A mode is a configuration of "annotators" and "key bindings":
 
@@ -87,7 +87,7 @@ Note: Keybindings that are not inside of a mode definition will always be availa
 
 #### Example
 
-Add the following to your `.ratrc` to build a simple file viewer/manager:
+Add the following to your `ratrc` to build a simple file viewer/manager:
 
 ```shell
 mode files
@@ -124,7 +124,7 @@ rat [--mode=<mode>] [--cmd=<command>]
 ```
 
 `--mode` defaults to `default`
-`--cmd` defaults to `cat ~/.config/rat/.ratrc`
+`--cmd` defaults to `cat ~/.config/rat/ratrc`
 
 ### Keybindings
 

--- a/lib/dotfiles.go
+++ b/lib/dotfiles.go
@@ -1,0 +1,25 @@
+package rat
+
+import (
+	"os"
+	"os/user"
+	"path/filepath"
+)
+
+var (
+	ConfigDir string
+)
+
+func init() {
+	xdg_config_path := os.Getenv("XDG_CONFIG_HOME")  // POSIX convention
+	if xdg_config_path != "" {
+		ConfigDir = filepath.Join(xdg_config_path, "rat")
+	} else {
+		usr, err := user.Current()
+		if err != nil {
+			panic(err)
+		}
+		ConfigDir = filepath.Join(usr.HomeDir, ".config", "rat")
+	}
+	SetAnnotatorsDir(filepath.Join(ConfigDir, "annotators"))
+}

--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"os"
-	"os/user"
 	"path/filepath"
 
 	rat "github.com/ericfreese/rat/lib"
@@ -15,7 +14,7 @@ var flags struct {
 }
 
 func init() {
-	flag.StringVar(&flags.cmd, "cmd", "cat ~/.config/rat/.ratrc", "command to run")
+	flag.StringVar(&flags.cmd, "cmd", "cat ~/.config/rat/ratrc", "command to run")
 	flag.StringVar(&flags.mode, "mode", "default", "name of mode")
 
 	flag.Parse()
@@ -30,17 +29,7 @@ func main() {
 
 	defer rat.Close()
 
-	var usr *user.User
-	usr, err = user.Current()
-	if err != nil {
-		panic(err)
-	}
-
-	configDir := filepath.Join(usr.HomeDir, ".config", "rat")
-
-	rat.SetAnnotatorsDir(filepath.Join(configDir, "annotators"))
-
-	if config, err := os.Open(filepath.Join(configDir, ".ratrc")); err == nil {
+	if config, err := os.Open(filepath.Join(rat.ConfigDir, "ratrc")); err == nil {
 		rat.LoadConfig(config)
 		config.Close()
 	}


### PR DESCRIPTION
1. Drop the '.' in '.ratrc'. Redundant since the parent directory is
hidden. Fixes #16.

2. Instead of hardcoding the location of rat's config directory, use
$XDG_CONFIG_HOME, following the convention on Unix-like systems.
  https://en.wikipedia.org/wiki/Freedesktop.org
  https://specifications.freedesktop.org/basedir-spec/latest

In the process I've created a new file for dotfile issues, which may be
useful for supporting #17 (loading multiple config files).

Open question: should we update the default `flags.cmd`? I've minimally
updated it for now, but it's still useless to anyone overriding
$XDG_CONFIG_HOME. I'm new to Go, and I don't know how to pass
non-literal defaults to flags. I also wonder if the default should be
something else.