### PR TITLE
Add a `source <file>` option to rat configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,16 @@ bindkey <key> <new-pager-mode> -- <cmd>
 
 Note: Keybindings that are not inside of a mode definition will always be available and do not have the special prefix behavior described above.
 
+#### Source configurations from separate files
+
+The `source` keyword starts a declaration of a separate config file
+
+```shell
+source <file>
+```
+
+- `file`: The name of a sibling to `ratrc` that contains valid rat configuration instructions
+
 #### Example
 
 Add the following to your `ratrc` to build a simple file viewer/manager:

--- a/lib/configurer.go
+++ b/lib/configurer.go
@@ -4,6 +4,8 @@ import (
 	"bufio"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 )
@@ -50,6 +52,8 @@ func (c *configurer) Process(rd io.Reader) {
 			c.ProcessBindkey(args)
 		case "mode":
 			c.ProcessMode(scanner, args)
+		case "source":
+			c.ProcessExternalConfig(args[0])
 		default:
 			panic(fmt.Sprintf("Unknown directive: '%s'", directive))
 		}
@@ -58,6 +62,15 @@ func (c *configurer) Process(rd io.Reader) {
 	if err := scanner.Err(); err != nil {
 		panic(err)
 	}
+}
+
+func (c *configurer) ProcessExternalConfig(fileName string) {
+	externalConfig, err := os.Open(filepath.Join(ConfigDir, fileName))
+	if err != nil {
+		panic(err)
+	}
+
+	c.Process(externalConfig)
 }
 
 func (c *configurer) ProcessBindkey(args []string) {


### PR DESCRIPTION
Source will load a sibling of `ratrc` into the configuration. This for
the configuration to be split into multiple files to prevent `ratrc`
from becoming unwieldly