### PR TITLE
Use exported `PATH` var instead of hardcoding path to annotator

### DIFF
--- a/lib/annotate.go
+++ b/lib/annotate.go
@@ -260,8 +260,11 @@ func (ea *externalAnnotator) readUint64(rd io.Reader) (uint64, error) {
 func (ea *externalAnnotator) Annotate(rd io.Reader) <-chan Annotation {
 	out := make(chan Annotation)
 
-	cmd := exec.Command(os.Getenv("SHELL"), "-c", fmt.Sprintf("%s%c%s", annotatorsDir, os.PathSeparator, ea.cmd))
-	cmd.Env = ContextEnvironment(ea.ctx)
+	env := ContextEnvironment(ea.ctx)
+	env = append(env, fmt.Sprintf("PATH=%s:%s", annotatorsDir, os.Getenv("PATH")))
+
+	cmd := exec.Command(os.Getenv("SHELL"), "-c", ea.cmd)
+	cmd.Env = env
 	cmd.Stdin = rd
 
 	stdout, err := cmd.StdoutPipe()


### PR DESCRIPTION
This is more robust and allows you to debug external annotators easily using `tee`.

For example:

```
mode foo
  annotate external foo -- tee -a input.log | regex 'foo+' | tee -a annotations.log
  ...
end
```

and then running separately:

`tail -f input.log`

and:

`tail -f annotations.log | hexdump -C`

to see what the annotator is receiving on STDIN and what annotations it is sending on STDOUT.